### PR TITLE
Pass mocked events to listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## next
+
+- Add readyStates as both static and and instance members
+
 ## 1.0.0
 
 Initial release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add readyStates as both static and and instance members
 - default response `status` to 200
+- Pass mocked `ProgressEvent` and `MockEvent` to event listeners
 
 ## 1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## next
 
 - Add readyStates as both static and and instance members
+- default response `status` to 200
 
 ## 1.0.0
 

--- a/src/MockRequest.ts
+++ b/src/MockRequest.ts
@@ -1,5 +1,6 @@
 import * as URL from "url";
 import MockXMLHttpRequest from "./MockXMLHttpRequest";
+import MockProgressEvent from "./polyfill/MockProgressEvent";
 
 /** The mocked request data */
 export default class MockRequest {
@@ -81,10 +82,10 @@ export default class MockRequest {
 
   /** Trigger progress event */
   progress(loaded: number, total?: number, lengthComputable?: boolean): void {
-    this._xhr.trigger("progress", {
+    this._xhr.trigger("progress", new MockProgressEvent("progress", {
       lengthComputable: lengthComputable || true,
       loaded,
       total,
-    });
+    }));
   }
 }

--- a/src/MockResponse.ts
+++ b/src/MockResponse.ts
@@ -79,7 +79,7 @@ export default class MockResponse {
 
     this._timeout = typeof timeout === "number"
       ? timeout
-      : 0;
+      : 1;
     return this;
   }
 }

--- a/src/MockXMLHttpRequest.ts
+++ b/src/MockXMLHttpRequest.ts
@@ -103,13 +103,13 @@ export default class MockXMLHttpRequest implements XMLHttpRequest {
   public msCachingEnabled: () => boolean;
 
   // Events
-  public onabort: (this: XMLHttpRequestEventTarget, ev: Event) => any;
-  public onerror: (this: XMLHttpRequestEventTarget, ev: ErrorEvent) => any;
-  public onload: (this: XMLHttpRequestEventTarget, ev: Event) => any;
-  public onloadend: (this: XMLHttpRequestEventTarget, ev: Event) => any;
-  public onloadstart: (this: XMLHttpRequestEventTarget, ev: Event) => any;
+  public onabort: (this: XMLHttpRequestEventTarget, ev: ProgressEvent) => any;
+  public onerror: (this: XMLHttpRequestEventTarget, ev: Event) => any;
+  public onload: (this: XMLHttpRequestEventTarget, ev: ProgressEvent) => any;
+  public onloadend: (this: XMLHttpRequestEventTarget, ev: ProgressEvent) => any;
+  public onloadstart: (this: XMLHttpRequestEventTarget, ev: ProgressEvent) => any;
   public onprogress: (this: XMLHttpRequestEventTarget, ev: ProgressEvent) => any;
-  public ontimeout: (this: XMLHttpRequestEventTarget, ev: Event) => any;
+  public ontimeout: (this: XMLHttpRequestEventTarget, ev: ProgressEvent) => any;
 
   private _events: any[] = [];
   private _sendTimeout: any;
@@ -267,9 +267,9 @@ export default class MockXMLHttpRequest implements XMLHttpRequest {
     return this._responseHeaders[name.toLowerCase()] || null;
   }
 
-  addEventListener<K extends keyof XMLHttpRequestEventMap>(
+  addEventListener<K extends keyof XMLHttpRequestEventTargetEventMap>(
     type: K,
-    listener: (event?: XMLHttpRequestEventMap[K]) => any,
+    listener: (event?: XMLHttpRequestEventTargetEventMap[K]) => any,
     useCapture?: boolean,
   ): void {
     this._events.push({

--- a/src/MockXMLHttpRequest.ts
+++ b/src/MockXMLHttpRequest.ts
@@ -15,6 +15,11 @@ const createEvent = (options: any, target: any, type: string) => {
 };
 
 export default class MockXMLHttpRequest implements XMLHttpRequest {
+  public static readonly UNSENT = 0;
+  public static readonly OPENED = 1;
+  public static readonly HEADERS_RECEIVED = 2;
+  public static readonly LOADING = 3;
+  public static readonly DONE = 4;
 
   public static handlers: any[] = [];
 
@@ -46,15 +51,16 @@ export default class MockXMLHttpRequest implements XMLHttpRequest {
     return null;
   }
 
-  readonly UNSENT = 0;
-  readonly OPENED = 1;
-  readonly HEADERS_RECEIVED = 2;
-  readonly LOADING = 3;
-  readonly DONE = 4;
-
   get handlers() {
     return MockXMLHttpRequest.handlers;
   }
+
+  // Somehow they are both defined on the instance and static method
+  public readonly UNSENT = 0;
+  public readonly OPENED = 1;
+  public readonly HEADERS_RECEIVED = 2;
+  public readonly LOADING = 3;
+  public readonly DONE = 4;
 
   // some libraries (like Mixpanel) use the presence of this field to check
   // if XHR is properly supported. See
@@ -115,7 +121,7 @@ export default class MockXMLHttpRequest implements XMLHttpRequest {
     this.responseText = null;
     this.responseXML = null;
 
-    this.readyState = this.UNSENT;
+    this.readyState = MockXMLHttpRequest.UNSENT;
   }
 
   /** Trigger an event */
@@ -139,7 +145,7 @@ export default class MockXMLHttpRequest implements XMLHttpRequest {
 
   open(method: string, url?: string, async?: boolean, user?: string, password?: string): void {
     this.reset();
-    this.readyState = this.OPENED;
+    this.readyState = MockXMLHttpRequest.OPENED;
     this.data = null;
 
     if (typeof url === "undefined") {
@@ -162,7 +168,7 @@ export default class MockXMLHttpRequest implements XMLHttpRequest {
   }
 
   send(data?: any): void {
-    this.readyState = this.LOADING;
+    this.readyState = MockXMLHttpRequest.LOADING;
     this.data = data;
 
     setTimeout(() => {
@@ -175,7 +181,7 @@ export default class MockXMLHttpRequest implements XMLHttpRequest {
           // - wait for the timeout time because many libs like jquery
           // and superagent use setTimeout to detect the error type
           this._sendTimeout = setTimeout(() => {
-            this.readyState = this.DONE;
+            this.readyState = MockXMLHttpRequest.DONE;
             this.trigger("timeout");
           }, timeout);
         } else {
@@ -185,14 +191,14 @@ export default class MockXMLHttpRequest implements XMLHttpRequest {
           this.responseType = "text";
           this.response = response.body();
           this.responseText = response.body(); // TODO: detect an object and return JSON, detect XML and return XML
-          this.readyState = this.DONE;
+          this.readyState = MockXMLHttpRequest.DONE;
 
           // trigger a load event because the request was received
           this.trigger("load");
         }
       } else {
         // trigger an error because the request was not handled
-        this.readyState = this.DONE;
+        this.readyState = MockXMLHttpRequest.DONE;
         this.trigger("error");
       }
     }, 0);
@@ -201,16 +207,16 @@ export default class MockXMLHttpRequest implements XMLHttpRequest {
   abort(): void {
     clearTimeout(this._sendTimeout);
 
-    if (this.readyState > this.UNSENT &&
-      this.readyState < this.DONE
+    if (this.readyState > MockXMLHttpRequest.UNSENT &&
+      this.readyState < MockXMLHttpRequest.DONE
     ) {
-      this.readyState = this.UNSENT;
+      this.readyState = MockXMLHttpRequest.UNSENT;
       this.trigger("abort");
     }
   }
 
   getAllResponseHeaders(): null | string {
-    if (this.readyState < this.HEADERS_RECEIVED) {
+    if (this.readyState < MockXMLHttpRequest.HEADERS_RECEIVED) {
       return null;
     }
 
@@ -221,7 +227,7 @@ export default class MockXMLHttpRequest implements XMLHttpRequest {
   }
 
   getResponseHeader(name: string): null | string {
-    if (this.readyState < this.HEADERS_RECEIVED) {
+    if (this.readyState < MockXMLHttpRequest.HEADERS_RECEIVED) {
       return null;
     }
 

--- a/src/MockXMLHttpRequest.ts
+++ b/src/MockXMLHttpRequest.ts
@@ -113,7 +113,7 @@ export default class MockXMLHttpRequest implements XMLHttpRequest {
     this._requestHeaders = {};
     this._responseHeaders = {};
 
-    this.status = 0;
+    this.status = 200;
     this.statusText = "";
 
     this.response = null;

--- a/src/__tests__/Builder.spec.ts
+++ b/src/__tests__/Builder.spec.ts
@@ -2,6 +2,7 @@ import { assert as t } from "chai";
 import * as sinon from "sinon";
 import * as window from "global";
 import mock from "../Builder";
+import MockProgressEvent from "../polyfill/MockProgressEvent";
 
 const noop = (res: any) => res;
 
@@ -132,6 +133,100 @@ describe("Builder", () => {
         t.equal(xhr.responseText, "123");
         done();
       };
+      xhr.send();
+    });
+
+    it("should call error callback", done => {
+      mock.get("/foo", (req, res) => null);
+
+      const xhr = new XMLHttpRequest();
+      xhr.addEventListener("error", ev => {
+        t.equal(ev instanceof MockProgressEvent, true);
+        t.equal(ev.type, "error");
+        done();
+      });
+      xhr.open("GET", "/foo");
+      xhr.send();
+    });
+
+    it("should call onreadystatechange callback", done => {
+      mock.get("/foo", (req, res) => null);
+
+      const xhr = new XMLHttpRequest();
+      xhr.onreadystatechange = ev => {
+        t.equal(ev instanceof MockProgressEvent, false);
+        t.equal(ev.type, "readystatechange");
+        done();
+      };
+      xhr.open("GET", "/foo");
+      xhr.send();
+    });
+
+    it("should call loadend callback", done => {
+      mock.get("/foo", (req, res) => null);
+
+      const xhr = new XMLHttpRequest();
+      xhr.addEventListener("loadend", ev => {
+        t.equal(ev instanceof MockProgressEvent, true);
+        t.equal(ev.type, "loadend");
+        done();
+      });
+      xhr.open("GET", "/foo");
+      xhr.send();
+    });
+
+    it("should call load callback", done => {
+      mock.get("/foo", (req, res) => res.body("foo"));
+
+      const xhr = new XMLHttpRequest();
+      xhr.addEventListener("load", ev => {
+        t.equal(ev instanceof MockProgressEvent, true);
+        t.equal(ev.type, "load");
+        done();
+      });
+      xhr.open("GET", "/foo");
+      xhr.send();
+    });
+
+    it("should call timeout callback", done => {
+      mock.get("/foo", (req, res) => res.timeout(true));
+
+      const xhr = new XMLHttpRequest();
+      xhr.addEventListener("timeout", ev => {
+        t.equal(ev instanceof MockProgressEvent, true);
+        t.equal(ev.type, "timeout");
+        done();
+      });
+      xhr.open("GET", "/foo");
+      xhr.send();
+    });
+
+    it("should call abort callback", done => {
+      mock.get("/foo", (req, res) => res.timeout(100));
+
+      const xhr = new XMLHttpRequest();
+      xhr.addEventListener("abort", ev => {
+        t.equal(ev instanceof MockProgressEvent, true);
+        t.equal(ev.type, "abort");
+        done();
+      });
+      xhr.open("GET", "/foo");
+      xhr.send();
+      xhr.abort();
+    });
+
+    it("should call loadstart callback", done => {
+      mock.get("/foo", (req, res) => res.body("hello"));
+
+      const xhr = new XMLHttpRequest();
+      xhr.addEventListener("loadstart", ev => {
+        t.equal(ev instanceof MockProgressEvent, true);
+        t.equal((ev as MockProgressEvent).loaded, 0);
+        t.equal((ev as MockProgressEvent).total, 0);
+        t.equal(ev.type, "loadstart");
+        done();
+      });
+      xhr.open("GET", "/foo");
       xhr.send();
     });
   });

--- a/src/__tests__/Builder.spec.ts
+++ b/src/__tests__/Builder.spec.ts
@@ -27,6 +27,14 @@ describe("Builder", () => {
     beforeEach(() => mock.setup());
     afterEach(() => mock.teardown());
 
+    it("should make readyStates available statically", () => {
+      t.equal(XMLHttpRequest.UNSENT, 0);
+      t.equal(XMLHttpRequest.OPENED, 1);
+      t.equal(XMLHttpRequest.HEADERS_RECEIVED, 2);
+      t.equal(XMLHttpRequest.LOADING, 3);
+      t.equal(XMLHttpRequest.DONE, 4);
+    });
+
     it("should allow registering the handler", done => {
       mock.mock((req, res) => res
         .status(200)

--- a/src/__tests__/MockResponse.spec.ts
+++ b/src/__tests__/MockResponse.spec.ts
@@ -16,7 +16,7 @@ describe("MockResponse", () => {
     const res = new MockResponse();
 
     res.timeout(true);
-    t.equal(res.timeout(), 0);
+    t.equal(res.timeout(), 1);
 
     res.timeout(100);
     t.equal(res.timeout(), 100);

--- a/src/__tests__/MockXMLHttpRequest.spec.ts
+++ b/src/__tests__/MockXMLHttpRequest.spec.ts
@@ -1,6 +1,7 @@
 import { assert as t } from "chai";
 import * as sinon from "sinon";
 import MockXMLHttpRequest from "../MockXMLHttpRequest";
+import MockProgressEvent from "../polyfill/MockProgressEvent";
 
 /* tslint:disable only-arrow-functions */
 
@@ -185,6 +186,8 @@ describe("MockXMLHttpRequest", () => {
 
       const xhr = new MockXMLHttpRequest();
       xhr.addEventListener("progress", event => {
+        t.equal(event instanceof MockProgressEvent, true);
+        t.equal(event.type, "progress");
         t.equal(event.lengthComputable, true);
         t.equal(event.loaded, 50);
         t.equal(event.total, 100);

--- a/src/polyfill/MockEvent.ts
+++ b/src/polyfill/MockEvent.ts
@@ -1,0 +1,51 @@
+export default class MockEvent implements Event {
+  readonly bubbles: boolean;
+  cancelBubble: boolean;
+  readonly cancelable: boolean;
+  readonly currentTarget: EventTarget;
+  readonly defaultPrevented: boolean;
+  readonly eventPhase: number;
+  readonly isTrusted: boolean;
+  returnValue: boolean;
+  readonly srcElement: Element | null;
+  readonly target: EventTarget;
+  readonly timeStamp: number;
+  readonly type: string;
+  readonly scoped: boolean;
+
+  readonly AT_TARGET: number;
+  readonly BUBBLING_PHASE: number;
+  readonly CAPTURING_PHASE: number;
+
+  constructor(typeArg: string, eventInitDict?: EventInit) {
+    this.type = typeArg;
+    Object.assign(this, eventInitDict);
+  }
+
+  initEvent(
+    eventTypeArg: string,
+    canBubbleArg: boolean,
+    cancelableArg: boolean,
+  ): void {
+    (this as any).type = eventTypeArg;
+    (this as any).bubbles = canBubbleArg;
+    (this as any).cancelable = cancelableArg;
+  }
+
+  preventDefault(): void {
+    (this as any).defaultPrevented = true;
+  }
+
+  stopImmediatePropagation(): void {
+    // TODO: not implemented
+  }
+
+  stopPropagation(): void {
+    // TODO: not implemented
+  }
+
+  deepPath(): EventTarget[] {
+    // TODO: not implemented
+    throw new Error("not implemented");
+  }
+}

--- a/src/polyfill/MockEvent.ts
+++ b/src/polyfill/MockEvent.ts
@@ -46,6 +46,6 @@ export default class MockEvent implements Event {
 
   deepPath(): EventTarget[] {
     // TODO: not implemented
-    throw new Error("not implemented");
+    return [];
   }
 }

--- a/src/polyfill/MockProgressEvent.ts
+++ b/src/polyfill/MockProgressEvent.ts
@@ -1,0 +1,28 @@
+import MockEvent from "./MockEvent";
+
+export default class MockProgressEvent extends MockEvent implements ProgressEvent {
+  public readonly lengthComputable: boolean;
+  public readonly loaded: number;
+  public readonly total: number;
+
+  constructor(typeArg: string, eventInitDict?: ProgressEventInit) {
+    super(typeArg, eventInitDict);
+    Object.assign(this, eventInitDict);
+  }
+
+  initProgressEvent(
+    typeArg: string,
+    canBubbleArg: boolean,
+    cancelableArg: boolean,
+    lengthComputableArg: boolean,
+    loadedArg: number,
+    totalArg: number,
+  ): void {
+    (this as any).type = typeArg;
+    (this as any).bubbles = canBubbleArg;
+    (this as any).cancelable = cancelableArg;
+    (this as any).lengthComputable = lengthComputableArg;
+    (this as any).loaded = loadedArg;
+    (this as any).total = totalArg;
+  }
+}

--- a/src/polyfill/__tests__/MockEvent.spec.ts
+++ b/src/polyfill/__tests__/MockEvent.spec.ts
@@ -1,0 +1,35 @@
+import { assert as t } from "chai";
+import MockEvent from "../MockEvent";
+
+describe("MockEvent", () => {
+  it("should initialize constructor args", () => {
+    const ev = new MockEvent("foo", { bubbles: false });
+    t.equal(ev.type, "foo");
+    t.equal(ev.bubbles, false);
+  });
+
+  it("should initEvent", () => {
+    const ev = new MockEvent("foo");
+    ev.initEvent("nope", true, true);
+    t.equal(ev.type, "nope");
+    t.equal(ev.bubbles, true);
+    t.equal(ev.cancelable, true);
+  });
+
+  it("should preventDefault", () => {
+    const ev = new MockEvent("foo");
+    ev.preventDefault();
+    t.equal(ev.defaultPrevented, true);
+  });
+
+  it("should deepPath", () => {
+    const ev = new MockEvent("foo");
+    t.deepEqual(ev.deepPath(), []);
+  });
+
+  it("should do nothing on not implemented methods", () => {
+    const ev = new MockEvent("foo");
+    ev.stopImmediatePropagation();
+    ev.stopPropagation();
+  });
+});

--- a/src/polyfill/__tests__/MockProgressEvent.spec.ts
+++ b/src/polyfill/__tests__/MockProgressEvent.spec.ts
@@ -1,0 +1,21 @@
+import { assert as t } from "chai";
+import MockProgressEvent from "../MockProgressEvent";
+
+describe("MockProgressEvent", () => {
+  it("should initialize constructor args", () => {
+    const ev = new MockProgressEvent("foo", { loaded: 10 });
+    t.equal(ev.type, "foo");
+    t.equal(ev.loaded, 10);
+  });
+
+  it("should initProgressEvent", () => {
+    const ev = new MockProgressEvent("foo");
+    ev.initProgressEvent("nope", true, true, true, 10, 20);
+    t.equal(ev.type, "nope");
+    t.equal(ev.bubbles, true);
+    t.equal(ev.cancelable, true);
+    t.equal(ev.lengthComputable, true);
+    t.equal(ev.loaded, 10);
+    t.equal(ev.total, 20);
+  });
+});


### PR DESCRIPTION
Mocks exists for the following classes:

- [x] `ProgressEvent`
- [x] `Event`

Mocked events:

- [x] `onprogress`
- [x] `onloadend`
- [x] `onreadystatechanged`
- [x] `onload`
- [x] `ontimeout`
- [x] `onabort`
- [x] `onloadstart`

TODO:

- [x] Add tests for `MockEvent`
- [x] Add tests for `MockProgressEvent`
- [x] Check event listener event typings