### PR TITLE
clean up types and support error

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The api is practically similar to the native [XMLHttpRequest](https://developer.
 | `body(): string` | Get response body. |
 | `body(body: string)` | Set response body. |
 | `timeout(): boolean | number` | Get weather the response will trigger a timeout. |
-| ```timeout(ms: boolean | number)``` | Set a timeout, otherwise default to the value set on the XHR object. |
+| `timeout(ms: boolean | number)` | Set a timeout, otherwise default to the value set on the XHR object. |
 | `progress(loaded: number, total: number, lengthComputable: boolean)` | Trigger progress event. Pass in loaded size, total size and if event is lengthComputable. |
 
 ## Special Thanks

--- a/README.md
+++ b/README.md
@@ -81,11 +81,11 @@ xhr.onreadystatechange = () => {
 | `setup()` | Replace the global `XMLHttpRequest` object with the `MockXMLHttpRequest`. |
 | `teardown()` | Restore the global `XMLHttpRequest` object to its original state. |
 | `reset()` | Remove all request handlers. |
-| `get(url: string | regex, callback)` | Create `GET` mock response for a specific url. |
-| `post(url: string | regex, callback)` | Create `POST` mock response for a specific url. |
-| `put(url: string | regex, callback)` | Create `PUT` mock response for a specific url. |
-| `patch(url: string | regex, callback)` | Create `PATCH` mock response for a specific url. |
-| `delete(url: string | regex, callback)` | Create `DELETE` mock response for a specific url. |
+| `get(url: string &#124; regex, callback)` | Create `GET` mock response for a specific url. |
+| `post(url: string &#124; regex, callback)` | Create `POST` mock response for a specific url. |
+| `put(url: string &#124; regex, callback)` | Create `PUT` mock response for a specific url. |
+| `patch(url: string &#124; regex, callback)` | Create `PATCH` mock response for a specific url. |
+| `delete(url: string &#124; regex, callback)` | Create `DELETE` mock response for a specific url. |
 | `mock(callback)` | Register mock response for every request. |
 
 ### MockXMLHttpRequest

--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ The api is practically similar to the native [XMLHttpRequest](https://developer.
 | `headers(headers: obejct)` | Set response headers. |
 | `body(): string` | Get response body. |
 | `body(body: string)` | Set response body. |
-| `timeout(): boolean | number` | Get weather the response will trigger a timeout. |
-| `timeout(ms: boolean | number)` | Set a timeout, otherwise default to the value set on the XHR object. |
+| `timeout(): boolean &#124; number` | Get weather the response will trigger a timeout. |
+| `timeout(ms: boolean &#124; number)` | Set a timeout, otherwise default to the value set on the XHR object. |
 | `progress(loaded: number, total: number, lengthComputable: boolean)` | Trigger progress event. Pass in loaded size, total size and if event is lengthComputable. |
 
 ## Special Thanks

--- a/README.md
+++ b/README.md
@@ -81,11 +81,11 @@ xhr.onreadystatechange = () => {
 | `setup()` | Replace the global `XMLHttpRequest` object with the `MockXMLHttpRequest`. |
 | `teardown()` | Restore the global `XMLHttpRequest` object to its original state. |
 | `reset()` | Remove all request handlers. |
-| `get(url: string &#124; regex, callback)` | Create `GET` mock response for a specific url. |
-| `post(url: string &#124; regex, callback)` | Create `POST` mock response for a specific url. |
-| `put(url: string &#124; regex, callback)` | Create `PUT` mock response for a specific url. |
-| `patch(url: string &#124; regex, callback)` | Create `PATCH` mock response for a specific url. |
-| `delete(url: string &#124; regex, callback)` | Create `DELETE` mock response for a specific url. |
+| `get(url: string | regex, callback)` | Create `GET` mock response for a specific url. |
+| `post(url: string | regex, callback)` | Create `POST` mock response for a specific url. |
+| `put(url: string | regex, callback)` | Create `PUT` mock response for a specific url. |
+| `patch(url: string | regex, callback)` | Create `PATCH` mock response for a specific url. |
+| `delete(url: string | regex, callback)` | Create `DELETE` mock response for a specific url. |
 | `mock(callback)` | Register mock response for every request. |
 
 ### MockXMLHttpRequest
@@ -115,8 +115,8 @@ The api is practically similar to the native [XMLHttpRequest](https://developer.
 | `headers(headers: obejct)` | Set response headers. |
 | `body(): string` | Get response body. |
 | `body(body: string)` | Set response body. |
-| `timeout(): boolean &#124; number` | Get weather the response will trigger a timeout. |
-| `timeout(ms: boolean &#124; number)` | Set a timeout, otherwise default to the value set on the XHR object. |
+| `timeout(): boolean | number` | Get weather the response will trigger a timeout. |
+| ```timeout(ms: boolean | number)``` | Set a timeout, otherwise default to the value set on the XHR object. |
 | `progress(loaded: number, total: number, lengthComputable: boolean)` | Trigger progress event. Pass in loaded size, total size and if event is lengthComputable. |
 
 ## Special Thanks

--- a/src/MockXMLHttpRequest.ts
+++ b/src/MockXMLHttpRequest.ts
@@ -1,3 +1,4 @@
+import { MockCallback } from "./Builder";
 import MockResponse from "./MockResponse";
 import MockRequest from "./MockRequest";
 import MockProgressEvent from "./polyfill/MockProgressEvent";
@@ -43,15 +44,15 @@ export default class MockXMLHttpRequest implements XMLHttpRequest {
   public static readonly LOADING = 3;
   public static readonly DONE = 4;
 
-  public static handlers: any[] = [];
+  public static handlers: MockCallback[] = [];
 
   /** Add a request handler */
-  static addHandler(fn: (req: MockRequest, res: MockResponse) => any): void {
+  static addHandler(fn: MockCallback): void {
     MockXMLHttpRequest.handlers.push(fn);
   }
 
   /** Remove a request handler */
-  static removeHandler(fn: (req: MockRequest, res: MockRequest) => any): MockXMLHttpRequest {
+  static removeHandler(fn: MockCallback): MockXMLHttpRequest {
     throw notImplementedError;
   }
 

--- a/src/__tests__/Builder.spec.ts
+++ b/src/__tests__/Builder.spec.ts
@@ -1,10 +1,10 @@
 import { assert as t } from "chai";
 import * as sinon from "sinon";
 import * as window from "global";
-import mock from "../Builder";
+import mock, { MockCallback } from "../Builder";
 import MockProgressEvent from "../polyfill/MockProgressEvent";
 
-const noop = (res: any) => res;
+const noop: MockCallback  = (req, res) => res;
 
 describe("Builder", () => {
   it("should setup and teardown the mock XMLHttpRequest class", () => {

--- a/src/__tests__/MockXMLHttpRequest.spec.ts
+++ b/src/__tests__/MockXMLHttpRequest.spec.ts
@@ -15,11 +15,25 @@ describe("MockXMLHttpRequest", () => {
       MockXMLHttpRequest.addHandler((req, res) => {
         t.equal(req.header("content-type"), "application/json");
         done();
+        return res;
       });
 
       const xhr = new MockXMLHttpRequest();
       xhr.open("/");
       xhr.setRequestHeader("Content-Type", "application/json");
+      xhr.send();
+    });
+
+    it("should error if we return null", done => {
+      MockXMLHttpRequest.addHandler(() => null);
+
+      const xhr = new MockXMLHttpRequest();
+      xhr.onerror = (ev) => {
+        t.isTrue(ev instanceof MockProgressEvent);
+        t.equal(ev.type, "error");
+        done();
+      };
+      xhr.open("/");
       xhr.send();
     });
   });
@@ -37,6 +51,7 @@ describe("MockXMLHttpRequest", () => {
       MockXMLHttpRequest.addHandler((req, res) => {
         t.equal(req.body(), "Hello World!");
         done();
+        return res;
       });
 
       const xhr = new MockXMLHttpRequest();
@@ -48,6 +63,7 @@ describe("MockXMLHttpRequest", () => {
       MockXMLHttpRequest.addHandler((req, res) => {
         t.equal(req.body(), null);
         done();
+        return res;
       });
 
       const xhr = new MockXMLHttpRequest();

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,5 @@ export { default as MockXMLHttpRequest } from "./MockXMLHttpRequest";
 export { default as MockXMLHttpRequestUpload } from "./MockXMLHttpRequestUpload";
 export { default as MockResponse } from "./MockResponse";
 export { default as MockRequest } from "./MockRequest";
+export { MockCallback, UrlMatcher } from "./Builder";
 export { default as default } from "./Builder";


### PR DESCRIPTION
I cleaned up the types, so they can be inferred most of the time and also exported them for easier reuse.
I also added support for erroring the response similar to `xhr-mock` when returning `null` from a handler.

@marvinhagemeister PTAL