### PR TITLE
Fixed bug with multiple handlers

### DIFF
--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -53,7 +53,7 @@ export class Builder {
         if (matcher(req)) {
           return fn(req, res);
         }
-        return res;
+        return null;
       };
     } else if (typeof method === "function") {
       handler = method;

--- a/src/__tests__/Builder.spec.ts
+++ b/src/__tests__/Builder.spec.ts
@@ -88,6 +88,35 @@ describe("Builder", () => {
       xhr.send();
     });
 
+    it("should resolve correct responses", done => {
+      mock.mock("GET", "/a", (req, res) => {
+        return res
+          .status(200)
+          .body("A");
+      });
+
+      mock.mock("GET", "/b", (req, res) => {
+        return res
+          .status(200)
+          .body("B");
+      });
+
+      const xhr = new XMLHttpRequest();
+      xhr.open("GET", "/a");
+      xhr.onload = () => {
+        t.equal(xhr.responseText, "A");
+        done();
+      };
+
+      const xhr2 = new XMLHttpRequest();
+      xhr2.open("GET", "/b");
+      xhr2.onload = () => {
+        xhr.send();
+        t.equal(xhr2.responseText, "B");
+      };
+      xhr2.send();
+    });
+
     it("should support POST method", done => {
       mock.post("/foo/123", (req, res) => res.body("123"));
 

--- a/src/__tests__/Builder.spec.ts
+++ b/src/__tests__/Builder.spec.ts
@@ -88,7 +88,7 @@ describe("Builder", () => {
       xhr.send();
     });
 
-    it("should resolve correct responses", done => {
+    it("should resolve correct responses", () => {
       mock.mock("GET", "/a", (req, res) => {
         return res
           .status(200)
@@ -101,20 +101,27 @@ describe("Builder", () => {
           .body("B");
       });
 
-      const xhr = new XMLHttpRequest();
-      xhr.open("GET", "/a");
-      xhr.onload = () => {
-        t.equal(xhr.responseText, "A");
-        done();
-      };
-
-      const xhr2 = new XMLHttpRequest();
-      xhr2.open("GET", "/b");
-      xhr2.onload = () => {
+      const promise1 = new Promise((resolve, reject) => {
+        const xhr = new XMLHttpRequest();
+        xhr.open("GET", "/a");
+        xhr.onload = () => {
+          t.equal(xhr.responseText, "A");
+          resolve();
+        };
         xhr.send();
-        t.equal(xhr2.responseText, "B");
-      };
-      xhr2.send();
+      });
+
+      const promise2 = new Promise((resolve, reject) => {
+        const xhr = new XMLHttpRequest();
+        xhr.open("GET", "/b");
+        xhr.onload = () => {
+          t.equal(xhr.responseText, "B");
+          resolve();
+        };
+        xhr.send();
+      });
+
+      return Promise.all([promise1, promise2]);
     });
 
     it("should support POST method", done => {


### PR DESCRIPTION
When using multiple MockCallbacks only first is tested. If callback's method and url do not match then empty MockResponse is being returned to callee.