### PR TITLE
Fixes timeout behavior when MockXMLHttpRequest has a timeout

### DIFF
--- a/src/MockXMLHttpRequest.ts
+++ b/src/MockXMLHttpRequest.ts
@@ -214,14 +214,9 @@ export default class MockXMLHttpRequest implements XMLHttpRequest {
       const response = MockXMLHttpRequest.handle(new MockRequest(this));
 
       if (response !== null) {
-        let timeout: number;
-        if (!response.timeout()) {
-           timeout = this.timeout;
-        } else if (!this.timeout) {
-          timeout = response.timeout();
-        } else {
-          timeout = Math.min(this.timeout, response.timeout());
-        }
+        const timeout = response.timeout() && this.timeout
+            ? Math.min(response.timeout(), this.timeout)
+            : response.timeout();
 
         if (timeout > 0) {
           // trigger a timeout event because the request timed timeout

--- a/src/MockXMLHttpRequest.ts
+++ b/src/MockXMLHttpRequest.ts
@@ -214,7 +214,14 @@ export default class MockXMLHttpRequest implements XMLHttpRequest {
       const response = MockXMLHttpRequest.handle(new MockRequest(this));
 
       if (response !== null) {
-        const timeout = Math.max(response.timeout(), this.timeout);
+        let timeout: number;
+        if (!response.timeout()) {
+           timeout = this.timeout;
+        } else if (!this.timeout) {
+          timeout = response.timeout();
+        } else {
+          timeout = Math.min(this.timeout, response.timeout());
+        }
 
         if (timeout > 0) {
           // trigger a timeout event because the request timed timeout

--- a/src/__tests__/MockXMLHttpRequest.spec.ts
+++ b/src/__tests__/MockXMLHttpRequest.spec.ts
@@ -71,7 +71,7 @@ describe("MockXMLHttpRequest", () => {
       xhr.send();
     });
 
-    it("should time out after 100ms", done => {
+    it("should time out after the response timeout (1ms) when it is lower than the request timeout (10ms)", done => {
       MockXMLHttpRequest.addHandler((req, res) => res.timeout(true));
 
       let start: any;
@@ -81,7 +81,7 @@ describe("MockXMLHttpRequest", () => {
       xhr.open("/");
       xhr.ontimeout = () => {
         end = Date.now();
-        t.isTrue(end - start >= 100);
+        t.isTrue(end - start >= 1);
         t.equal(xhr.readyState, 4);
         done();
       };
@@ -89,7 +89,7 @@ describe("MockXMLHttpRequest", () => {
       xhr.send();
     });
 
-    it("should time out after 100ms even though the timeout is set to timeout after 10ms", done => {
+    it("should time out after the request timeout (10ms) when it is lower than the response timeout (100ms)", done => {
       MockXMLHttpRequest.addHandler((req, res) => {
         return res.timeout(100);
       });
@@ -102,7 +102,7 @@ describe("MockXMLHttpRequest", () => {
       let end: any;
       xhr.ontimeout = () => {
         end = Date.now();
-        t.isTrue(end - start >= 100);
+        t.isTrue(end - start >= 10);
         t.equal(xhr.readyState, xhr.DONE);
         done();
       };


### PR DESCRIPTION

Currently, the presence of a timeout on a _request_, forces `MockXMLHttpRequest.send()` to take the timeout path, even when the response returned by the handler indicates no timeout.  Additionally, if the response indicates a short timeout, a long timeout on the request is preferred.

Basically, this means it's not possible to test the non-timeout path of code that sends a request with a timeout.  i.e., code like this:
```ts
const req = new XmlHttpRequest();
// Indicate the ability to handle a timeout.
req.timeout = 1000;
req.ontimeout = () => ...;
// ...but express the expected happy-path as a regular onload event
req.onload = () => ...;
```
cannot have its onload path tested (even with `res.timeout(false)` or `res.timeout(0)`), because the presence of `req.timeout` forces the timeout path, due to the `Math.max()` here:
https://github.com/marvinhagemeister/xhr-mocklet/blob/master/src/MockXMLHttpRequest.ts#L217

I believe that `MockXMLHttpRequest::timeout` should only indicate the _capacity_ to handle a timeout, but `MockXMLHttpResponse::timeout` should indicate the choice to take the timeout path.

This PR updates `MockXMLHttpRequest::send()` so that it only takes the timeout path when a response timeout is indicated.
